### PR TITLE
Pass string to init_logging instead of logging.INFO flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ from thoth.common import OpenShift
 from thoth.common import init_logging
 
 
-init_logging({"thoth.osiris_build_observer": os.getenv("LOG_LEVEL", logging.INFO)})
+init_logging({"thoth.osiris_build_observer": os.getenv("LOG_LEVEL", "INFO")})
 
 _LOGGER = logging.getLogger("thoth.osiris_build_observer")
 


### PR DESCRIPTION
Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   app.py