### PR TITLE
OpenShift templates are independent of Osiris configMap

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -49,20 +49,20 @@ objects:
               name: osiris-observer
               resources: {}
               env:
-                - name: DRY_RUN
-                  value: 'false'
+                - name: LOG_LEVEL
+                  value: DEBUG
+                - name: KUBERNETES_VERIFY_TLS
+                  value: '0'
+                - name: MIDDLETIER_NAMESPACE
+                  value: thoth-test-core
                 - name: OPENSHIFT_API_URL
                   value: 'https://paas.upshift.redhat.com'
                 - name: OSIRIS_HOST_NAME
-                  valueFrom:
-                    configMapKeyRef:
-                      key: OSIRIS_HOST_NAME
-                      name: osiris
+                  value: ${OSIRIS_HOST_URL}
                 - name: OSIRIS_HOST_PORT
-                  valueFrom:
-                    configMapKeyRef:
-                      key: OSIRIS_HOST_PORT
-                      name: osiris
+                  value: '5000'
+                - name: OVERWRITE_EXISTING_LOGS
+                  value: '1'
       triggers:
         - type: ConfigChange
         - type: ImageChange
@@ -73,3 +73,9 @@ objects:
             from:
               kind: ImageStreamTag
               name: osiris-observer:latest
+
+parameters:
+  - description: Osiris host url.
+    displayName: Osiris host.
+    required: true
+    name: OSIRIS_HOST_URL

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -94,20 +94,21 @@ objects:
               name: osiris-observer
               resources: {}
               env:
-                - name: DRY_RUN
-                  value: 'false'
+                - name: LOG_LEVEL
+                  value: DEBUG
+                - name: KUBERNETES_VERIFY_TLS
+                  value: '0'
+                - name: MIDDLETIER_NAMESPACE
+                  value: thoth-test-core
                 - name: OPENSHIFT_API_URL
-                  value: https://paas.upshift.redhat.com
+                  value: 'https://paas.upshift.redhat.com'
                 - name: OSIRIS_HOST_NAME
-                  valueFrom:
-                    configMapKeyRef:
-                      key: OSIRIS_HOST_NAME
-                      name: osiris
+                  value: ${OSIRIS_HOST_URL}
                 - name: OSIRIS_HOST_PORT
-                  valueFrom:
-                    configMapKeyRef:
-                      key: OSIRIS_HOST_PORT
-                      name: osiris
+                  value: '5000'
+                - name: OVERWRITE_EXISTING_LOGS
+                  value: '1'
+
       triggers:
         - type: ConfigChange
         - type: ImageChange
@@ -138,3 +139,8 @@ parameters:
     required: true
     name: IMAGE_STREAM_TAG
     value: 'latest'
+
+  - description: Osiris host url.
+    displayName: Osiris host.
+    required: true
+    name: OSIRIS_HOST_URL


### PR DESCRIPTION
With the idea of observer being independent, let observer have defined
environment variables for itself without the need of Osiris ConfigMap
being in the same namespace

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   openshift/deployment-template.yaml
modified:   openshift/template.yaml