### PR TITLE
Use remote mode by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,7 +126,9 @@ class RetrySession(requests.Session):
         """Send request and return whether it was successful."""
         resp = self.send(request, timeout=60)
 
-        success = resp.status_code == HTTPStatus.ACCEPTED
+        success = resp.status_code in (
+            HTTPStatus.ACCEPTED, HTTPStatus.CREATED, HTTPStatus.OK
+        )
 
         if success:
             _LOGGER.info("Success.")
@@ -150,8 +152,7 @@ if __name__ == "__main__":
             'content-type': 'application/json'
         },
         params={
-            'mode': 'cluster',
-            'force': 1
+            'mode': 'remote',
         }
     )
 


### PR DESCRIPTION
- in remote mode, Osiris API does not gather build logs by itself,
instead, they are assumed to be sent by observer

- check for other successful statuses except for HTTPStatus.OK

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   app.py